### PR TITLE
Problems with createElement and defaultText

### DIFF
--- a/src/fDOMDocument.php
+++ b/src/fDOMDocument.php
@@ -396,7 +396,47 @@ namespace TheSeer\fDOM {
             }
             return $this->isSameNode($node->ownerDocument);
         }
-
+        
+        /**
+         * Create a new fDOMElement. Other than in the original
+         * implementation it is possible to use a string with 
+         * Entities like "&"
+         *
+         * @param string $namespaceURI
+         * @param string $qualifiedName
+         * @param string $value
+         * 
+         * @return fDOMElement
+         */
+        public function createElement($name, $value = null)
+        {
+            $element = parent::createElement($name);
+            if (!is_null($value)) {
+                $element->appendTextNode($value);
+            }
+            return $element;
+        }
+        
+        /**
+         * Create a new fDOMElement. Other than in the original
+         * implementation it is possible to use a string with 
+         * Entities like "&"
+         *
+         * @param string $namespaceURI
+         * @param string $qualifiedName
+         * @param string $value
+         * 
+         * @return fDOMElement
+         */
+        public function createElementNS($namespaceURI, $qualifiedName, $value = null)
+        {
+            $element = parent::createElementNS($namespaceURI, $qualifiedName);
+            if (!is_null($value)) {
+                $element->appendTextNode($value);
+            }
+            return $element;
+        }
+        
     } // fDOMDocument
 
 }

--- a/src/fDOMElement.php
+++ b/src/fDOMElement.php
@@ -101,12 +101,9 @@ namespace TheSeer\fDOM {
          * @return fDOMElement Reference to created fDOMElement
          */
         public function appendElement($name, $content = null) {
-            $node = $this->ownerDocument->createElement($name);
-            $this->appendChild($node);
-            if (!is_null($content)) {
-                $node->nodeValue = $content;
-            }
-            return $node;
+            return $this->appendChild(
+                $this->ownerDocument->createElement($name, $content)
+            );
         }
 
         /**
@@ -119,12 +116,9 @@ namespace TheSeer\fDOM {
          * @return fDOMElement Reference to created fDOMElement
          */
         public function appendElementNS($ns, $name, $content = null) {
-            $node = $this->ownerDocument->createElementNS($ns, $name);
-            $this->appendChild($node);
-            if (!is_null($content)) {
-                $node->nodeValue = $content;
-            }
-            return $node;
+            return $this->appendChild(
+                $this->ownerDocument->createElementNS($ns, $name, $content)
+            );
         }
 
         /**
@@ -137,11 +131,25 @@ namespace TheSeer\fDOM {
          * @return fDOMElement Reference to created fDOMElement
          */
         public function appendElementPrefix($prefix, $name, $content = null) {
-            $node = $this->ownerDocument->createElementPrefix($prefix, $name, $content);
-            $this->appendChild($node);
-            return $node;
+            return $this->appendChild(
+                $this->ownerDocument->createElementPrefix($prefix, $name, $content)
+            );
         }
 
+        /**
+         * Create a new TextNode and append it
+         * 
+         * @param string $text
+         * 
+         * @return \DOMText 
+         */
+        public function appendTextNode($text)
+        {
+            return $this->appendChild(
+                $this->ownerDocument->createTextNode($text)
+            );
+        }
+        
         /**
          * Wrapper to DomElement->getAttribute with default value option
          *


### PR DESCRIPTION
Hey Arne

If i create a new element with a string containing the char "&" as second parameter, fDOM cut the char "&" and all following chars off. Different than DOMDocument, fDOMDocument doesn't create a Warning in this case.

I wrote a solution witch escapes illegal chars. By the way i created the usefull fDOMElement-Method appendTextNode().

Greetings and see you soon
Markus
