### PR TITLE
Methods appendElement and appendElementNS created for DOMDocument

### DIFF
--- a/src/fDOMDocument.php
+++ b/src/fDOMDocument.php
@@ -396,6 +396,35 @@ namespace TheSeer\fDOM {
             }
             return $this->isSameNode($node->ownerDocument);
         }
+        
+        /**
+         * Create a new element and append it as documentElement
+         *
+         * @param $name     Name of not element to create
+         * @param $content  Optional content to be set
+         *
+         * @return fDOMElement Reference to created fDOMElement
+         */
+        public function appendElement($name, $content = null) {
+            return $this->appendChild(
+                $this->createElement($name, $content)
+            );
+        }
+
+        /**
+         * Create a new element in given namespace and append it as documentElement
+         *
+         * @param $ns       Namespace of node to create
+         * @param $name     Name of not element to create
+         * @param $content  Optional content to be set
+         *
+         * @return fDOMElement Reference to created fDOMElement
+         */
+        public function appendElementNS($ns, $name, $content = null) {
+            return $this->appendChild(
+                $this->createElementNS($ns, $name, $content)
+            );
+        }
 
     } // fDOMDocument
 


### PR DESCRIPTION
Hey Arne

I have added two methods to fDOMDocument(): Now it is possible to do:

$dom = new fDOMDocument;
$root = $dom->appendElement('root', 'My Root Node');

Greetings, Markus

PS: If you don't want to merge my previous Pull-Request you should edit these Methods, because they create a TextNode even thought you pass no Default Text
