### PR TITLE
Make hhvm 3.2.0 happy

### DIFF
--- a/src/fDOMXPath.php
+++ b/src/fDOMXPath.php
@@ -71,7 +71,7 @@ namespace TheSeer\fDOM {
 
         public function query($q, \DOMNode $ctx = null, $registerNodeNS = true) {
             libxml_clear_errors();
-            if (version_compare(PHP_VERSION, '5.3.3', '<') || strpos(PHP_VERSION, 'hiphop')) {
+            if (version_compare(PHP_VERSION, '5.3.3', '<') || strpos(PHP_VERSION, 'hiphop') || strpos(PHP_VERSION, 'hhvm')) {
                 $rc = parent::query($q, ($ctx instanceof \DOMNode) ? $ctx : $this->doc->documentElement);
             } else {
                 $rc = parent::query($q, ($ctx instanceof \DOMNode) ? $ctx : $this->doc->documentElement, $registerNodeNS);
@@ -85,7 +85,7 @@ namespace TheSeer\fDOM {
 
         public function evaluate($q, \DOMNode $ctx = null, $registerNodeNS = true) {
             libxml_clear_errors();
-            if (version_compare(PHP_VERSION, '5.3.3', '<') || strpos(PHP_VERSION, 'hiphop')) {
+            if (version_compare(PHP_VERSION, '5.3.3', '<') || strpos(PHP_VERSION, 'hiphop') || strpos(PHP_VERSION, 'hhvm')) {
                 $rc = parent::evaluate($q, ($ctx instanceof \DOMNode) ? $ctx : $this->doc->documentElement);
             } else {
                 $rc = parent::evaluate($q, ($ctx instanceof \DOMNode) ? $ctx : $this->doc->documentElement, $registerNodeNS);


### PR DESCRIPTION
Hi!

I'm using this as part of https://github.com/sebastianbergmann/hhvm-wrapper and it gave me the following error with hhvm 3.2.0:

```
Warning: Too many arguments for DOMXPath::query(), expected 2 in /backend/vendor/theseer/fdomdocument/src/fDOMXPath.php on line 77
```

So here's the fix for that. My hhvm version (that's the same one currently used by travis-ci, btw.):

```
$ hhvm --version
HipHop VM 3.2.0 (rel)
Compiler: tags/HHVM-3.2.0-0-g01228273b8cf709aacbd3df1c51b1e690ecebac8
Repo schema: c52ba40f4a246d35a88f1dfc1daf959851ced8aa
$ echo '<?php var_dump(PHP_VERSION);' > test.php; hhvm test.php
string(11) "5.6.99-hhvm"
```

(I left the "hiphop" thing in for backwards compatibilty, though people running hhvm are probably upgrading rather swiftly)
