### PR TITLE
Recomend using a version constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ As fDOMDocument is a library and does not provide any cli tools, you can only ad
 
     {
         "require": {
-            "theseer/fdomdocument": "1.6.0"
+            "theseer/fdomdocument": "1.6.*"
         }
     }
 


### PR DESCRIPTION
We shouldn't really recommend people locking the version to 1.6.0 because it means they won't be able to get any fixes from 1.6.1 if it is ever released.
