### PR TITLE
Fix load empty xmlstring

### DIFF
--- a/src/fDOMDocument.php
+++ b/src/fDOMDocument.php
@@ -159,6 +159,9 @@ namespace TheSeer\fDOM {
          * @return boolean
          */
         public function loadXML($source, $options = LIBXML_NONET) {
+            if ($source == '') {
+                throw new fDOMException('empty string not allowed', fDOMException::ParseError);
+            }
             $this->xp = NULL;
             $tmp = parent :: loadXML($source, $options);
             if (!$tmp || libxml_get_last_error()) {

--- a/src/fDOMDocument.php
+++ b/src/fDOMDocument.php
@@ -138,6 +138,9 @@ namespace TheSeer\fDOM {
          * @return bool|mixed
          */
         public function load($fname, $options = LIBXML_NONET) {
+            if ($fname == '') {
+                throw new fDOMException('empty filename is not allowed', fDOMException::ParseError);
+            }
             $this->xp = NULL;
             $tmp = parent :: load($fname, $options);
             if (!$tmp || libxml_get_last_error()) {
@@ -183,6 +186,9 @@ namespace TheSeer\fDOM {
          * @return boolean
          */
         public function loadHTMLFile($fname, $options = NULL) {
+            if ($fname == '') {
+                throw new fDOMException('empty filename is not allowed', fDOMException::ParseError);
+            }
             $this->xp = NULL;
             if (version_compare(PHP_VERSION, '5.4.0', '<')) {
                 if ($options != NULL) {
@@ -211,6 +217,9 @@ namespace TheSeer\fDOM {
          * @return boolean
          */
         public function loadHTML($source, $options = NULL) {
+            if ($source == '') {
+                throw new fDOMException('empty string not allowed', fDOMException::ParseError);
+            }
             $this->xp = NULL;
             if (version_compare(PHP_VERSION, '5.4.0', '<')) {
                 if ($options != NULL) {

--- a/tests/fDOMDocument.test.php
+++ b/tests/fDOMDocument.test.php
@@ -91,6 +91,27 @@ namespace TheSeer\fDOM\Tests {
         /**
          * @expectedException \TheSeer\fDOM\fDOMException
          */
+        public function testAttemptingToLoadWithEmptyFilenameThrowsException() {
+            $this->dom->load('');
+        }
+
+        /**
+         * @expectedException \TheSeer\fDOM\fDOMException
+         */
+        public function testAttemptingToLoadHTMLWithAnEmptyFilenameThrowsException() {
+            $this->dom->loadHTMLFile('');
+        }
+
+        /**
+         * @expectedException \TheSeer\fDOM\fDOMException
+         */
+        public function testAttemptingToLoadHMLWithAnEmptyStringThrowsException() {
+            $this->dom->loadHTML('');
+        }
+
+        /**
+         * @expectedException \TheSeer\fDOM\fDOMException
+         */
         public function testloadingInvalidXMLStringThrowsException() {
             $this->dom->loadXML('<?xml version="1.0" ?><broken>');
         }

--- a/tests/fDOMDocument.test.php
+++ b/tests/fDOMDocument.test.php
@@ -84,6 +84,13 @@ namespace TheSeer\fDOM\Tests {
         /**
          * @expectedException \TheSeer\fDOM\fDOMException
          */
+        public function testAttemptingToLoadAnEmptyXMLStringThrowsException() {
+            $this->dom->loadXML('');
+        }
+
+        /**
+         * @expectedException \TheSeer\fDOM\fDOMException
+         */
         public function testloadingInvalidXMLStringThrowsException() {
             $this->dom->loadXML('<?xml version="1.0" ?><broken>');
         }


### PR DESCRIPTION
According to the PHP-Manual using load, loadXML LoadHTML and loadHTMLFile with an empty string or filename will generate a warning which is not generated by libxml and can not be handled by libxml's error handling functions. In my opionion this leads to bad client code. So i added checks for the empty string/filename cases and throw a fDOMException. Maybe you consider this pull request or you may have some better ideas to handle such cases.  