### PR TITLE
Fix for PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ php:
     - 5.3
     - 5.4
     - 5.5
+    - 5.6
+    - 7.0
+    - 7.1
+    - nightly
     - hhvm
 
 notifications:
@@ -11,5 +15,15 @@ notifications:
 
 matrix:
   allow_failures:
+    - php: nightly
     - php: hhvm
   fast_finish: true
+
+before_script:
+  - composer self-update
+  - composer install
+  - composer require "phpunit/phpunit ^4.8.35|^5.6|^6.0"
+
+script:
+  - vendor/bin/phpunit --verbose
+

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
         "php": ">=5.3.3",
         "ext-dom": "*",
-        "lib-libxml": "*"
+        "lib-libxml": "*",
+        "phpunit/phpunit": "^4.8.35|^5.6|^6.0"
     },
     "autoload": {
         "classmap": [

--- a/src/XPathQuery.php
+++ b/src/XPathQuery.php
@@ -191,7 +191,7 @@ namespace TheSeer\fDOM {
          */
         private function buildQuery(fDOMXPath $xp, array $values = NULL) {
             $backup = $this->values;
-            if (count($values) > 0) {
+            if (is_array($values) && count($values) > 0) {
                 foreach($values as $k => $v) {
                     $this->bind($k, $v);
                 }

--- a/tests/Translator.test.php
+++ b/tests/Translator.test.php
@@ -4,7 +4,7 @@ namespace TheSeer\fDOM\Tests {
 
     use TheSeer\fDOM\CSS\Translator;
 
-    class TranslatorTest extends \PHPUnit_Framework_TestCase {
+    class TranslatorTest extends \PHPUnit\Framework\TestCase {
 
         /**
          * @dataProvider provider

--- a/tests/XPathQuery.test.php
+++ b/tests/XPathQuery.test.php
@@ -44,7 +44,7 @@ namespace TheSeer\fDOM\Tests {
     use TheSeer\fDOM\XPathQuery;
     use TheSeer\fDOM\fDOMDocument;
 
-    class XPathQueryTest extends \PHPUnit_Framework_TestCase {
+    class XPathQueryTest extends \PHPUnit\Framework\TestCase {
 
         private $dom;
 

--- a/tests/fDOMDocument.test.php
+++ b/tests/fDOMDocument.test.php
@@ -48,7 +48,7 @@ namespace TheSeer\fDOM\Tests {
      * @author     Arne Blankerts <arne@blankerts.de>
      * @copyright  Arne Blankerts <arne@blankerts.de>, All rights reserved.
      */
-    class fDOMDocumentTest extends \PHPUnit_Framework_TestCase {
+    class fDOMDocumentTest extends \PHPUnit\Framework\TestCase {
 
         /**
          * @var fDOMDocument

--- a/tests/fDOMDocumentFragment.test.php
+++ b/tests/fDOMDocumentFragment.test.php
@@ -49,7 +49,7 @@ namespace TheSeer\fDOM\Tests {
      * @author     Arne Blankerts <arne@blankerts.de>
      * @copyright  Arne Blankerts <arne@blankerts.de>, All rights reserved.
      */
-    class fDOMDocumentFragmentTest extends \PHPUnit_Framework_TestCase {
+    class fDOMDocumentFragmentTest extends \PHPUnit\Framework\TestCase {
 
         /**
          * @var fDOMDocument

--- a/tests/fDOMElement.test.php
+++ b/tests/fDOMElement.test.php
@@ -49,7 +49,7 @@ namespace TheSeer\fDOM\Tests {
      * @author     Arne Blankerts <arne@blankerts.de>
      * @copyright  Arne Blankerts <arne@blankerts.de>, All rights reserved.
      */
-    class fDOMElementTest extends \PHPUnit_Framework_TestCase {
+    class fDOMElementTest extends \PHPUnit\Framework\TestCase {
 
         /**
          * @var fDOMDocument

--- a/tests/fDOMXPath.test.php
+++ b/tests/fDOMXPath.test.php
@@ -49,7 +49,7 @@ namespace TheSeer\fDOM\Tests {
      * @author     Arne Blankerts <arne@blankerts.de>
      * @copyright  Arne Blankerts <arne@blankerts.de>, All rights reserved.
      */
-    class fDOMXPathTest extends \PHPUnit_Framework_TestCase {
+    class fDOMXPathTest extends \PHPUnit\Framework\TestCase {
 
         /**
          * @var TheSeer\fDOM\fDOMDocument


### PR DESCRIPTION
Without this:

```
There were 5 errors:

1) TheSeer\fDOM\Tests\XPathQueryTest::testBoundValueForKeyGetsApplied
count(): Parameter must be an array or an object that implements Countable

/work/GIT/fDOMDocument/src/XPathQuery.php:194
/work/GIT/fDOMDocument/src/XPathQuery.php:116
/work/GIT/fDOMDocument/tests/XPathQuery.test.php:73

2) TheSeer\fDOM\Tests\XPathQueryTest::testAppliedValueForKeyIsUsedOnQueryAndReturnsNode
count(): Parameter must be an array or an object that implements Countable

/work/GIT/fDOMDocument/src/XPathQuery.php:194
/work/GIT/fDOMDocument/src/XPathQuery.php:148
/work/GIT/fDOMDocument/tests/XPathQuery.test.php:79

3) TheSeer\fDOM\Tests\XPathQueryTest::testAppliedValueForKeyIsUsedOnEvaluateAndReturnsNode
count(): Parameter must be an array or an object that implements Countable

/work/GIT/fDOMDocument/src/XPathQuery.php:194
/work/GIT/fDOMDocument/src/XPathQuery.php:132
/work/GIT/fDOMDocument/tests/XPathQuery.test.php:96

4) TheSeer\fDOM\Tests\XPathQueryTest::testCallToQueryOneReturnsOneNode
count(): Parameter must be an array or an object that implements Countable

/work/GIT/fDOMDocument/src/XPathQuery.php:194
/work/GIT/fDOMDocument/src/XPathQuery.php:162
/work/GIT/fDOMDocument/tests/XPathQuery.test.php:112

5) TheSeer\fDOM\Tests\XPathQueryTest::testQueryCanBeRunWithStandardDomDocument
count(): Parameter must be an array or an object that implements Countable

/work/GIT/fDOMDocument/src/XPathQuery.php:194
/work/GIT/fDOMDocument/src/XPathQuery.php:148
/work/GIT/fDOMDocument/tests/XPathQuery.test.php:118

ERRORS!
Tests: 124, Assertions: 163, Errors: 5.
```