### PR TITLE
Various fixes to composer and travis

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /build export-ignore
+/src/autoloade.php export-ignore
 /tests export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+/build export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/build.xml export-ignore
+/package.xml export-ignore
+/pear.sh export-ignore
+/phpcs.xml export-ignore
+/phpunit.xml.dist export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 /build export-ignore
-/src/autoloade.php export-ignore
+/src/autoload.php export-ignore
 /tests export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /fDOMDocument-1.1.0.tgz
 .idea
 build
+composer.lock
+composer.phar
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,12 @@ php:
     - nightly
     - hhvm
 
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 notifications:
   email: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ matrix:
 before_script:
   - composer self-update
   - composer install
-  - composer require "phpunit/phpunit ^4.8.35|^5.6|^6.0"
 
 script:
   - vendor/bin/phpunit --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ matrix:
 before_script:
   - composer self-update
   - composer install
+  - composer require --dev "phpunit/phpunit ^4.8.35|^5.6|^6.0"
 
 script:
   - vendor/bin/phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,5 @@
         "classmap": [
             "src/"
         ]
-    },
-    "require-dev": {
-        "phpunit/phpunit": "^4.8.35|^5.6|^6.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,5 +22,8 @@
         "classmap": [
             "src/"
         ]
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^6.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,6 @@
         ]
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.1"
+        "phpunit/phpunit": "^4.8.35|^5.6|^6.1"
     }
 }


### PR DESCRIPTION
* Do not export test etc. when installing as distribution through composer
* Add caching to travis
* Set PHPUnit version in composer.json and use composer to install it with `composer install`.